### PR TITLE
fixes for compat with peerlibrary:reactive-publish, fixes #3

### DIFF
--- a/tests/publication-collector.test.js
+++ b/tests/publication-collector.test.js
@@ -120,7 +120,7 @@ describe('PublicationCollector', () => {
       const doc = {_id: id, foo: 'bar'};
       collector.added('documents', doc._id, doc);
 
-      assert.deepEqual(collector.responseData.documents[id], doc);
+      assert.deepEqual(collector._documents.documents[id], doc);
     });
   });
 
@@ -133,8 +133,8 @@ describe('PublicationCollector', () => {
       collector.collect('publication');
       collector.removed('documents', doc._id);
 
-      assert.notOk(collector.responseData.documents[doc._id]);
-      assert.equal(Object.keys(collector.responseData.documents).length, 9);
+      assert.notOk(collector._documents.documents[doc._id]);
+      assert.equal(Object.keys(collector._documents.documents).length, 9);
     });
   });
 


### PR DESCRIPTION
This required implementing some missing methods and renaming
the responseData to _documents which is more standard with
the original LiveData implementation.