### PR TITLE
Don't try to operate on a document that doesn't exist

### DIFF
--- a/publication-collector.js
+++ b/publication-collector.js
@@ -72,14 +72,17 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
 
     const existingDocument = this._documents[collection][id];
     const fieldsNoId = _.omit(fields, '_id');
-    _.extend(existingDocument, fieldsNoId);
 
-    // Delete all keys that were undefined in fields (except _id)
-    _.forEach(fields, (value, key) => {
-      if (value === undefined) {
-        delete existingDocument[key];
-      }
-    });
+    if (existingDocument) {
+      _.extend(existingDocument, fieldsNoId);
+
+      // Delete all keys that were undefined in fields (except _id)
+      _.forEach(fields, (value, key) => {
+        if (value === undefined) {
+          delete existingDocument[key];
+        }
+      });
+    }
   }
 
   removed(collection, id) {


### PR DESCRIPTION
We started getting about 100 errors of 
```
Exception in queued task: TypeError: Cannot set property 'ancestors' of undefined
```

This skips trying to operating on `existingDocument` when it doesn't exist.