### PR TITLE
Don't pass the callback to the handler

### DIFF
--- a/publication-collector.js
+++ b/publication-collector.js
@@ -27,9 +27,6 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
   }
 
   collect(name, ...args) {
-    const handler = Meteor.server.publish_handlers[name];
-    const result = handler.call(this, ...args);
-
     if (_.isFunction(args[args.length - 1])) {
       const callback = args.pop();
       this.on('ready', collections => {
@@ -37,6 +34,9 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
         this.observeHandles.forEach(handle => handle.stop());
       });
     }
+
+    const handler = Meteor.server.publish_handlers[name];
+    const result = handler.call(this, ...args);
 
     // TODO -- we should check that result has _publishCursor? What does _runHandler do?
     if (result) {

--- a/tests/publication-collector.test.js
+++ b/tests/publication-collector.test.js
@@ -109,6 +109,18 @@ describe('PublicationCollector', () => {
 
       collector.collect('publicationWithArgs', 'foo', 'bar');
     });
+
+    it('should support optional publication arguments', (done) => {
+      Meteor.publish('publicationWithOptionalArg', function(arg1 = 'foo') {
+        assert.equal(arg1, 'foo');
+        this.ready();
+        done();
+      });
+
+      const collector = new PublicationCollector();
+
+      collector.collect('publicationWithOptionalArg', function(){});
+    });
   });
 
   describe('Added', () => {


### PR DESCRIPTION
The publish handler was being passed the callback function as an argument. This can cause issues with publish functions that set default values for the last parameter.

For example:

```
Meteor.publish('files', function(limit=10) {
...
```

```
const collector = new PublicationCollector();
collector.collect('files', function(collections) {
...
```

Currently, the limit value will be set to the callback function, instead of 10. Moving these lines until after the `args.pop()` method is called removes the callback from the argument list.