### PR TITLE
Support publish functions using the low-level added/changed/removed interface, fixes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Based on https://github.com/stubailo/meteor-rest/blob/devel/packages/rest/http-s
 
 ## Releases
 
+- `1.0.6` - Fix an issue with "ready" event being emitted more than once ([#16](https://github.com/johanbrook/meteor-publication-collector/pull/16)). Thanks @nkahnfr!
 - `1.0.5` - Fix an issue when publish handlers are using default arguments ([#15](https://github.com/johanbrook/meteor-publication-collector/pull/15)). Thanks @dmihal!
 - `1.0.4` - Don't try to operate on a document that doesn't exist in `changed` callback. Thanks @zenweasel, from [#13](https://github.com/johanbrook/meteor-publication-collector/pull/13)!
 - `1.0.3` - Fix compatibility with `peerlibrary:reactive-publish` package (bug #3), fixed in [#10](https://github.com/johanbrook/meteor-publication-collector/pull/10). Thanks [@hexsprite](https://github.com/hexsprite)!

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   name: 'johanbrook:publication-collector',
-  version: '1.0.5',
+  version: '1.0.6',
   summary: 'Test a Meteor publication by collecting its output.',
   documentation: 'README.md',
   git: 'https://github.com/johanbrook/meteor-publication-collector.git',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publication-collector",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Test a Meteor publication by collecting its output.",
   "scripts": {
     "test": "SERVER_TEST_REPORTER='dot' meteor test-packages --once --driver-package dispatch:mocha ./",

--- a/publication-collector.js
+++ b/publication-collector.js
@@ -19,7 +19,6 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
     this._documents = {};
     this.unblock = () => {};
     this.userId = context.userId;
-    this.observeHandles = [];
     this._idFilter = {
       idStringify: MongoID.idStringify,
       idParse: MongoID.idParse
@@ -83,9 +82,9 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
       try {
         // for each cursor we call _publishCursor method which starts observing the cursor and
         // publishes the results.
-        this.observeHandles = cursors.map((cur) => {
+        cursors.forEach((cur) => {
           this._ensureCollectionInRes(cur._getCollectionName());
-          return cur._publishCursor(this);
+          cur._publishCursor(this);
         });
       } catch (e) {
         this.error(e);
@@ -159,9 +158,6 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
   stop() {
     // Synchronously calls each of the listeners registered for the "stop" event
     this.emit('stop');
-    // XXX: not necessary since we process "onStop" calls
-    // Tears down all established live queries
-    // this.observeHandles.forEach(handle => handle.stop());
   }
 
   error(error) {

--- a/publication-collector.js
+++ b/publication-collector.js
@@ -27,30 +27,78 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
   }
 
   collect(name, ...args) {
+    let callback;
+    // extracts optional callback from latest argument
     if (_.isFunction(args[args.length - 1])) {
-      const callback = args.pop();
-      this.on('ready', collections => {
-        callback(collections);
-        this.observeHandles.forEach(handle => handle.stop());
-      });
+      callback = args.pop();
     }
+    // adds a one time listener function for the "ready" event
+    this.once('ready', (collections) => {
+      if (_.isFunction(callback)) {
+        callback(collections);
+      }
+      // immediately stop the subscription
+      this.stop();
+    });
 
     const handler = Meteor.server.publish_handlers[name];
     const result = handler.call(this, ...args);
 
-    // TODO -- we should check that result has _publishCursor? What does _runHandler do?
-    if (result) {
-      // array-ize
-      this.observeHandles = [].concat(result).map(cur => {
-        if (cur._cursorDescription && cur._cursorDescription.collectionName) {
-          this._ensureCollectionInRes(cur._cursorDescription.collectionName);
-        }
+    this._publishHandlerResult(result);
+  }
 
-        return cur._publishCursor(this);
-      });
+  /**
+   * Reproduces "_publishHandlerResult" processing
+   * @see {@link https://github.com/meteor/meteor/blob/master/packages/ddp-server/livedata_server.js#L1045}
+   */
+  _publishHandlerResult(res) {
+    const cursors = [];
+
+    // publication handlers can return a collection cursor, an array of cursors or nothing.
+    if (this._isCursor(res)) {
+      cursors.push(res);
+    } else if (Array.isArray(res)) {
+      // check all the elements are cursors
+      const areCursors = res.reduce((valid, cur) => valid && this._isCursor(cur), true);
+      if (!areCursors) {
+        this.error(new Error('Publish function returned an array of non-Cursors'));
+        return;
+      }
+      // find duplicate collection names
+      const collectionNames = {};
+      for (let i = 0; i < res.length; ++i) {
+        const collectionName = res[i]._getCollectionName();
+        if ({}.hasOwnProperty.call(collectionNames, collectionName)) {
+          this.error(new Error(
+            `Publish function returned multiple cursors for collection ${collectionName}`
+          ));
+          return;
+        }
+        collectionNames[collectionName] = true;
+        cursors.push(res[i]);
+      }
     }
 
-    this.ready();
+    if (cursors.length > 0) {
+      try {
+        // for each cursor we call _publishCursor method which starts observing the cursor and
+        // publishes the results.
+        this.observeHandles = cursors.map((cur) => {
+          this._ensureCollectionInRes(cur._getCollectionName());
+          return cur._publishCursor(this);
+        });
+      } catch (e) {
+        this.error(e);
+        return;
+      }
+      // mark subscription as ready (_publishCursor does NOT call ready())
+      this.ready();
+    } else if (res) {
+      // truthy values other than cursors or arrays are probably a
+      // user mistake (possible returning a Mongo document via, say,
+      // `coll.findOne()`).
+      this.error(new Error('Publish function can only return a Cursor or an array of Cursors'));
+    }
   }
 
   added(collection, id, fields) {
@@ -99,19 +147,29 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
   }
 
   ready() {
+    // Synchronously calls each of the listeners registered for the "ready" event
     this.emit('ready', this._generateResponse());
   }
 
-  onStop() {
-    // no-op
+  onStop(callback) {
+    // Adds a one time listener function for the "stop" event
+    this.once('stop', callback);
   }
 
   stop() {
-    // no-op
+    // Synchronously calls each of the listeners registered for the "stop" event
+    this.emit('stop');
+    // XXX: not necessary since we process "onStop" calls
+    // Tears down all established live queries
+    // this.observeHandles.forEach(handle => handle.stop());
   }
 
   error(error) {
     throw error;
+  }
+
+  _isCursor(c) {
+    return c && c._publishCursor;
   }
 
   _ensureCollectionInRes(collection) {

--- a/tests/publication-collector.test.js
+++ b/tests/publication-collector.test.js
@@ -31,7 +31,18 @@ describe('PublicationCollector', () => {
       });
     });
 
-    it('should allow a ObjectID as _id', done => {
+    it('should collect documents from a publication using low-level added/changed/removed interface', (done) => {
+      const collector = new PublicationCollector();
+
+      collector.collect('publicationUsingLowLevelACRInterface', collections => {
+        assert.typeOf(collections.counts, 'array');
+        assert.equal(collections.counts.length, 1, 'collects 1 document');
+        assert.sameDeepMembers(collections.counts, [{ _id: 'Documents', count: 10 }]);
+        done();
+      });
+    });
+
+    it('should allow a ObjectID as _id', (done) => {
       Documents.remove({});
       Documents.insert({_id: new Mongo.ObjectID()});
 
@@ -119,7 +130,7 @@ describe('PublicationCollector', () => {
 
       const collector = new PublicationCollector();
 
-      collector.collect('publicationWithOptionalArg', function(){});
+      collector.collect('publicationWithOptionalArg');
     });
   });
 

--- a/tests/publications.js
+++ b/tests/publications.js
@@ -12,6 +12,13 @@ Meteor.publish('publicationWithSeveralCursors', function() {
   return [Documents.find(), Books.find(), Meteor.users.find()];
 });
 
+Meteor.publish('publicationUsingLowLevelACRInterface', function() {
+  const count = Documents.find().count();
+
+  this.added('counts', 'Documents', { count });
+  this.ready();
+});
+
 Meteor.publish('publicationWithUser', function() {
 
   if (!this.userId || this.userId !== 'foo') {


### PR DESCRIPTION
Here is my proposal to both fix issue #16 and to mimic more closely the processing done internally by Meteor when dealing with subscriptions (specially [```_publishHandlerResult ```](https://github.com/meteor/meteor/blob/master/packages/ddp-server/livedata_server.js#L1045)).

Let me know if you'd like me to adjust anything.