### PR TITLE
Resolves #20 - Works with peerlibrary:reactive-publish "autorun"

### DIFF
--- a/publication-collector.js
+++ b/publication-collector.js
@@ -23,6 +23,7 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
       idStringify: MongoID.idStringify,
       idParse: MongoID.idParse
     };
+    this._isDeactivated = () => {};
   }
 
   collect(name, ...args) {


### PR DESCRIPTION
peerlibrary:reactive-publish needs ‘_isDeactivated’, it has been “stubbed” to a function that does nothing.