### PR TITLE
docs(readme): add information about where the package should be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This package makes testing publications in Meteor easier and nicer.
 
 Instead of resorting to exporting or exposing your publication functions for doing testing, this package lets you "subscribe" to a given publication and assert its returned results.
 
+**This package works on the server side and must be only imported on the server side.** 
+
 ## Installation
 
 ```


### PR DESCRIPTION
Hi,

I have been struggling about 2 hours because I imported the package on the client side and when I imported it I had an object "undefined" x).

So just a little update on the README.md to indicate that the package should only be imported on the server side.

Thanks for your work.

Regards