### PR TITLE
Stop the subscription if an error occurs in the callback

### DIFF
--- a/publication-collector.js
+++ b/publication-collector.js
@@ -39,12 +39,14 @@ PublicationCollector = class PublicationCollector extends EventEmitter {
     }
 
     const completeCollecting = (collections) => {
-      if (_.isFunction(callback)) {
-        callback(collections);
+      try {
+        if (_.isFunction(callback)) {
+          callback(collections);
+        }
+      } finally {
+        // stop the subscription
+        this.stop();
       }
-
-      // stop the subscription
-      this.stop();
     };
 
     // adds a one time listener function for the "ready" event

--- a/tests/publication-collector.test.js
+++ b/tests/publication-collector.test.js
@@ -172,6 +172,22 @@ describe('PublicationCollector', () => {
 
       done();
     });
+
+    it('stops the publication if an error is thrown in the callback', (done) => {
+      const collector = new PublicationCollector();
+
+      collector.onStop(() => {
+        done();
+      });
+
+      try {
+        collector.collect('publication', collections => {
+          const foo = collections.nothing.length;
+        });
+      } catch (e) {
+        // Exception is not important here.
+      }
+    });
   });
 
   describe('Added', () => {

--- a/tests/publication-collector.test.js
+++ b/tests/publication-collector.test.js
@@ -173,20 +173,25 @@ describe('PublicationCollector', () => {
       done();
     });
 
-    it('stops the publication if an error is thrown in the callback', (done) => {
+    it('stops the publication if an error is thrown in the callback', () => {
       const collector = new PublicationCollector();
 
+      let stopMethodCalled = false;
       collector.onStop(() => {
-        done();
+        stopMethodCalled = true;
       });
 
+      let exception;
       try {
         collector.collect('publication', collections => {
-          const foo = collections.nothing.length;
+          throw new Error('Test');
         });
       } catch (e) {
-        // Exception is not important here.
+        exception = e;
       }
+
+      assert.isTrue(stopMethodCalled);
+      assert.instanceOf(exception, Error);
     });
   });
 


### PR DESCRIPTION
Here's a fix for something I ran into while playing with https://github.com/nlhuykhang/meteor-publish-join.

If an error occurs in the callback of `PublicationCollector.collect()` the `stop` method of the publication is never called.

This code makes sure that the error is thrown on (as before) and that the `stop` method of the publication is called.