### PR TITLE
Fix usage of async _publishCursor in Meteor 3

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   name: "johanbrook:publication-collector",
-  version: "2.0.0-rc.0",
+  version: "2.0.0-rc.1",
   summary: "Test a Meteor publication by collecting its output.",
   documentation: "README.md",
   git: "https://github.com/johanbrook/meteor-publication-collector.git",
@@ -15,7 +15,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom(["1.3", "2.8.0", "3.0-rc.0"]);
+  api.versionsFrom(["3.0-rc.0"]);
 
   api.use(["ecmascript", "underscore", "mongo", "check"], "server");
 

--- a/publication-collector.js
+++ b/publication-collector.js
@@ -89,7 +89,7 @@ export class PublicationCollector extends EventEmitter {
    * Reproduces "_publishHandlerResult" processing
    * @see {@link https://github.com/meteor/meteor/blob/master/packages/ddp-server/livedata_server.js#L1045}
    */
-  _publishHandlerResult(res) {
+  async _publishHandlerResult(res) {
     const cursors = [];
 
     // publication handlers can return a collection cursor, an array of cursors or nothing.
@@ -139,10 +139,10 @@ export class PublicationCollector extends EventEmitter {
       try {
         // for each cursor we call _publishCursor method which starts observing the cursor and
         // publishes the results.
-        cursors.forEach((cur) => {
+        await Promise.all(cursors.map((cur) => {
           this._ensureCollectionInRes(cur._getCollectionName());
-          cur._publishCursor(this);
-        });
+          return cur._publishCursor(this)
+        }));
       } catch (e) {
         this.error(e);
         return;


### PR DESCRIPTION
_publishCursor is async, and we must await it in order for collector to consistently pull data. This makes this change incompatible with Meteor 2.x